### PR TITLE
Updated regedit paths to support ansible 2.8

### DIFF
--- a/tasks/psm_hardening.yml
+++ b/tasks/psm_hardening.yml
@@ -43,19 +43,19 @@
 
     - name: Enable AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: AutoAdminLogon
         data: 1
 
     - name: Set Default Username for AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: DefaultUsername
         data: "{{ ansible_user }}"
 
     - name: Set Default Password for AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: DefaultPassword
         data: "{{ ansible_password }}"
 
@@ -86,19 +86,19 @@
 
     - name: Remove AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: AutoAdminLogon
         state: absent
 
     - name: Remove Username for AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: DefaultUsername
         state: absent
 
     - name: Remove Password for AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: DefaultPassword
         state: absent
 

--- a/tasks/psm_prerequisites.yml
+++ b/tasks/psm_prerequisites.yml
@@ -25,19 +25,19 @@
 
     - name: Enable AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: AutoAdminLogon
         data: 1
 
     - name: Set Default Username for AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: DefaultUsername
         data: "{{ ansible_user }}"
 
     - name: Set Default Password for AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: DefaultPassword
         data: "{{ ansible_password }}"
 
@@ -80,19 +80,19 @@
 
     - name: Remove AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: AutoAdminLogon
         state: absent
 
     - name: Remove Username for AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: DefaultUsername
         state: absent
 
     - name: Remove Password for AutoAdminLogon
       win_regedit:
-        path: 'HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+        path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon
         name: DefaultPassword
         state: absent
 


### PR DESCRIPTION
Altered win_regedit path values in psm _prerequisites to prevent below error breaking PSM provisioning when using Ansible 2.8.

```
TASK [psm : Enable AutoAdminLogon] *********************************************
fatal: [52.236.135.26]: FAILED! => {"changed": false, "data_changed": false, "data_type_changed": false, "msg": "failed to create registry key at HKLM:\\\\SOFTWARE\\\\Microsoft\\\\Windows NT\\\\CurrentVersion\\\\Winlogon: Exception calling \"CreateSubKey\" with \"1\" argument(s): \"The specified path is invalid.\r\n\""}
```