### PR TITLE
Call the PSM Hardening after the registration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ psm_artifact_name: "psm.zip"
 psm_component_folder: "Privileged Session Manager"
 psm_installationautomation_folder: "{{ psm_extract_folder }}\\{{ psm_component_folder }}\\InstallationAutomation"
 psm_registrationtool_location: "{{ psm_extract_folder }}\\{{ psm_component_folder }}\\RegistrationTool"
+psm_hardening_location: "{{ psm_extract_folder }}\\{{ psm_component_folder }}\\Hardening"
 
 psm_installation_drive: "C:"
 psm_installation_path: "{{ psm_installation_drive }}\\Program Files (x86)\\CyberArk"

--- a/tasks/psm_clean.yml
+++ b/tasks/psm_clean.yml
@@ -45,6 +45,12 @@
     dest: "{{ psm_base_bin_drive }}\\Cyberark\\PSM"
     remote_src: true
 
+- name: Keep Hardening folder
+  ansible.windows.win_copy:
+    src: "{{ psm_hardening_location }}"
+    dest: "{{ psm_base_bin_drive }}\\Cyberark\\PSM"
+    remote_src: true
+
 - name: Delete the deployment folder
   ansible.windows.win_file:
     path: "{{ psm_extract_folder }}"


### PR DESCRIPTION
Making sure the Hardening folder will not be deleted during the deployment. That will allow the OutOfDomainHardening step to pass and not to fail.